### PR TITLE
fix(cms): bypass strapi cli in runtime image

### DIFF
--- a/apps/strapi-cms/Dockerfile
+++ b/apps/strapi-cms/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=build --chown=node:node /app/yarn.lock ./yarn.lock
 COPY --from=build --chown=node:node /app/.yarnrc.yml ./.yarnrc.yml
 COPY --from=build --chown=node:node /app/node_modules ./node_modules
 COPY --from=build --chown=node:node /app/apps/strapi-cms/package.json ./apps/strapi-cms/package.json
+COPY --from=build --chown=node:node /app/apps/strapi-cms/start.js ./apps/strapi-cms/start.js
 COPY --from=build --chown=node:node /app/apps/strapi-cms/dist ./apps/strapi-cms/dist
 COPY --from=build --chown=node:node /app/apps/strapi-cms/public ./apps/strapi-cms/public
 COPY --from=build --chown=node:node /app/apps/strapi-cms/database ./apps/strapi-cms/database
@@ -44,4 +45,4 @@ USER node
 
 EXPOSE 1337
 
-CMD ["node", "/app/node_modules/@strapi/strapi/bin/strapi.js", "start"]
+CMD ["node", "./start.js"]

--- a/apps/strapi-cms/Dockerfile.dev
+++ b/apps/strapi-cms/Dockerfile.dev
@@ -33,4 +33,4 @@ USER node
 
 EXPOSE 1337
 
-CMD ["node", "/app/node_modules/@strapi/strapi/bin/strapi.js", "start"]
+CMD ["node", "./start.js"]

--- a/apps/strapi-cms/start.js
+++ b/apps/strapi-cms/start.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const { createStrapi } = require('@strapi/core');
+
+const appDir = process.cwd();
+const distDir = path.resolve(appDir, 'dist');
+
+createStrapi({ appDir, distDir }).start();


### PR DESCRIPTION
## Summary
- add a dedicated CMS runtime entrypoint that calls `createStrapi({ appDir, distDir })` directly
- update the prod and dev CMS Dockerfiles to start via that entrypoint instead of the Strapi CLI
- keep the runtime image minimal without relying on Yarn/Corepack or CLI TypeScript project detection

## Root Cause
After the previous fix removed Yarn from runtime startup, the container still launched Strapi through the CLI command path. Strapi's CLI detects TypeScript projects by looking for `tsconfig.json`; the slim production runtime image does not include that file or the TS sources, so the CLI misclassified the app as plain JS and treated the app root as `distDir`.

That made Strapi load config from `/app/apps/strapi-cms/config` instead of `/app/apps/strapi-cms/dist/config`, so `database` never resolved and startup crashed with:

`Cannot destructure property 'client' of 'db.config.connection' as it is undefined.`

## Testing
- `docker build -f apps/strapi-cms/Dockerfile -t codex-strapi-cms:test .`
- `docker run --rm -e NODE_ENV=production -e CORS_ORIGIN='["https://officialdavidtaylor.com"]' -e APP_KEYS='a,b,c,d' -e API_TOKEN_SALT='salt' -e ADMIN_JWT_SECRET='adminsecret' -e TRANSFER_TOKEN_SALT='transfersalt' -e ENCRYPTION_KEY='encryptkeyencryptkeyencryptkey12' -e JWT_SECRET='jwtsecret' -e DATABASE_HOST='127.0.0.1' codex-strapi-cms:test`

## Validation Note
The rebuilt container no longer fails with the config-shape error. In the verification run above it proceeds to a normal Postgres connection attempt and exits with `ECONNREFUSED 127.0.0.1:5432`, which confirms Strapi now loads the compiled runtime config correctly.
