### PR TITLE
[codex] optimize record cover images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.env.mac-mini
+config.yml
 
 # macOS-specific files
 .DS_Store

--- a/docker/mac-mini/docker-compose.production.yml
+++ b/docker/mac-mini/docker-compose.production.yml
@@ -94,7 +94,7 @@ services:
       - '127.0.0.1:${STRAPI_LOCAL_PORT:-1337}:1337'
 
   cloudflared:
-    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2026.2.1}
+    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2026.3.0}
     container_name: portfolio-cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run

--- a/src/lib/server/records.ts
+++ b/src/lib/server/records.ts
@@ -7,6 +7,11 @@ import { z } from 'astro/zod';
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const PAGE_SIZE = 100;
 const RECORDS_COLLECTION_TAG = 'records';
+const RECORD_COVER_FORMAT = 'thumbnail';
+
+const strapiImageFormatSchema = z.object({
+  url: z.string().min(1),
+});
 
 const strapiRecordSchema = z.object({
   title: z.string().min(1),
@@ -16,6 +21,10 @@ const strapiRecordSchema = z.object({
     name: z.string().min(1),
   }),
   coverArt: z.object({
+    formats: z
+      .record(z.string(), strapiImageFormatSchema)
+      .nullable()
+      .optional(),
     url: z.string().min(1),
   }),
   giver: z.string().nullable(),
@@ -121,6 +130,12 @@ function toPublicAssetUrl(assetUrl: string, publicBaseUrl: string): string {
   return new URL(assetUrl, publicBaseUrl).toString();
 }
 
+function getOptimizedCoverUrl(record: StrapiRecord): string {
+  return (
+    record.coverArt.formats?.[RECORD_COVER_FORMAT]?.url ?? record.coverArt.url
+  );
+}
+
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -133,7 +148,10 @@ function toLiveRecordEntry(
     id: record.slug,
     data: {
       artistName: record.artist.name,
-      coverUrl: toPublicAssetUrl(record.coverArt.url, config.strapiPublicUrl),
+      coverUrl: toPublicAssetUrl(
+        getOptimizedCoverUrl(record),
+        config.strapiPublicUrl
+      ),
       giver: record.giver,
       receivedOn: record.receivedOn,
       slug: record.slug,

--- a/src/pages/my-record-collection.astro
+++ b/src/pages/my-record-collection.astro
@@ -84,6 +84,10 @@ try {
                 src={record.data.coverUrl}
                 alt=""
                 role="presentation"
+                width="80"
+                height="80"
+                loading="lazy"
+                decoding="async"
                 class="max-w-20 rounded-sm shadow-sm"
               />
               <div class="h-full">

--- a/yarn.lock
+++ b/yarn.lock
@@ -21241,11 +21241,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

- Committed the pending repo maintenance updates as `fix: repo maintenance`.
- Updated the record collection loader to prefer Strapi's generated thumbnail asset for cover art instead of the original upload.
- Added explicit 80x80 dimensions plus lazy async decoding on the record collection cover images.

## Why

The record collection page renders album covers at 80x80, including on desktop, so fetching the original cover art wastes bandwidth. Using the generated thumbnail keeps the rendered behavior the same while returning a much smaller optimized image URL, with a fallback to the original URL if an asset has no generated formats.

## Validation

- `ASTRO_TELEMETRY_DISABLED=1 yarn build`