### PR TITLE
fix: normalize yarn lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -21241,11 +21241,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

- Restored the TypeScript patch hash/checksum in `yarn.lock` to the values generated by Corepack/Yarn 4.5.0.

## Why

CI runs `yarn install --immutable` using the repo's `packageManager` value, `yarn@4.5.0`. The squashed change left a lockfile entry generated by a different Yarn version, so CI refused to continue because the lockfile would have been modified.

## Validation

- `docker run --rm -v /Users/dtaylor/Documents/project/officialdavidtaylor-com:/workspace -v /workspace/node_modules -v /workspace/.yarn -w /workspace node:22-bookworm-slim sh -lc "corepack enable && yarn install --immutable"`